### PR TITLE
Add country code to the options

### DIFF
--- a/gbsearch.go
+++ b/gbsearch.go
@@ -36,6 +36,10 @@ func Search(searchType SearchType, searchTerm string, options *Options) (*Result
 			query.Add("langRestrict", *options.languageCode)
 		}
 
+		if options.countryCode != nil {
+			query.Add("country", *options.countryCode)
+		}
+
 		if options.startIndex != nil {
 			query.Add("startIndex", strconv.Itoa(*options.startIndex))
 		}

--- a/options.go
+++ b/options.go
@@ -76,6 +76,7 @@ type Options struct {
 	projection        *ProjectionType
 	orderBy           *OrderType
 	languageCode      *string
+	countryCode       *string
 }
 
 // DefaultOptions returns a new Options struct set with the default values.  Currently, the default
@@ -139,5 +140,13 @@ func (this *Options) SetOrderBy(o OrderType) {
 func (this *Options) SetLanguageCode(lc string) {
 	if lc != "" {
 		this.languageCode = &lc
+	}
+}
+
+// SetCountryCode will let us set which country IP to restrict our search to.  Use the two leter
+// standard country code, such as "us", "fr", etc...
+func (this *Options) SetCountryCode(cc string) {
+	if cc != "" {
+		this.countryCode = &cc
 	}
 }


### PR DESCRIPTION
In some cases (like when you use tor) google cannot determine your location and
refuses to provide results. Providing the country fixes the problem:
https://productforums.google.com/forum/#!topic/books-api/7FQ-622q-jI
